### PR TITLE
Add-Captval-trait-for-validation

### DIFF
--- a/crates/captval/src/captval.rs
+++ b/crates/captval/src/captval.rs
@@ -1,0 +1,14 @@
+//! Captval Trait
+use crate::{Error, Response};
+// use async_trait::async_trait;
+use std::{future::Future, pin::Pin};
+
+/// Captval trait
+pub trait Captval {
+    /// valid response function
+    fn valid_response(
+        &self,
+        secret: &str,
+        uri: Option<String>,
+    ) -> Pin<Box<dyn Future<Output = Result<Response, Error>>>>;
+}

--- a/crates/captval/src/lib.rs
+++ b/crates/captval/src/lib.rs
@@ -283,7 +283,7 @@
 // mod client;
 // #[doc(hidden)]
 // pub(crate) mod domain;
-// mod captval;
+mod captval;
 mod error;
 // mod request;
 mod hcaptcha;
@@ -300,5 +300,5 @@ pub use response::Response;
 
 // pub(crate) use remoteip::Remoteip;
 
-// pub use crate::captval::Hcaptcha;
+pub use crate::captval::Captval;
 // pub use captval_derive::*;


### PR DESCRIPTION
- uncomment captval module to include its functionality
- adjust exports to include Captval for external use