### PR TITLE
♻️ refactor(captval_derive): remove unused variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📝 docs(license)-add Apache and MIT licenses(pr [#39])
 - 🔧 chore(release)-add release configuration file(pr [#41])
 - ✅ test(captval_derive)-add basic test cases for macro expansion(pr [#43])
+- ♻️ refactor(captval_derive)-remove unused variable(pr [#44])
 
 ### Security
 
@@ -106,5 +107,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#41]: https://github.com/jerus-org/captval/pull/41
 [#42]: https://github.com/jerus-org/captval/pull/42
 [#43]: https://github.com/jerus-org/captval/pull/43
+[#44]: https://github.com/jerus-org/captval/pull/44
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/captval_derive/src/lib.rs
+++ b/crates/captval_derive/src/lib.rs
@@ -161,7 +161,6 @@ fn impl_captval(ast: &DeriveInput) -> TokenStream {
                     };
                 }
 
-                let mut captcha = String::new();
                 #captcha
                 #remoteip
                 #sitekey


### PR DESCRIPTION
- delete unused `captcha` variable from `impl_captval` function to clean up code