### PR TITLE
✅ test(expand): add test for expanded contact form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(release)-add release configuration file(pr [#41])
 - ✅ test(captval_derive)-add basic test cases for macro expansion(pr [#43])
 - ♻️ refactor(captval_derive)-remove unused variable(pr [#44])
+- ✅ test(expand)-add test for expanded contact form(pr [#45])
 
 ### Security
 
@@ -108,5 +109,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#42]: https://github.com/jerus-org/captval/pull/42
 [#43]: https://github.com/jerus-org/captval/pull/43
 [#44]: https://github.com/jerus-org/captval/pull/44
+[#45]: https://github.com/jerus-org/captval/pull/45
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/captval_derive/tests/expand/complete_struct.expanded.rs
+++ b/crates/captval_derive/tests/expand/complete_struct.expanded.rs
@@ -1,0 +1,66 @@
+use captval_derive::Captval;
+pub struct ContactForm {
+    name: String,
+    #[allow(dead_code)]
+    phone: String,
+    email: String,
+    #[allow(dead_code)]
+    message: String,
+    #[captcha]
+    token: String,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for ContactForm {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field5_finish(
+            f,
+            "ContactForm",
+            "name",
+            &self.name,
+            "phone",
+            &self.phone,
+            "email",
+            &self.email,
+            "message",
+            &self.message,
+            "token",
+            &&self.token,
+        )
+    }
+}
+impl Captval for ContactForm {
+    fn valid_response(
+        &self,
+        secret: &str,
+        uri: Option<String>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<captval::Response, captval::Error>>>,
+    > {
+        let mut client = captval::Client::new();
+        if let Some(u) = uri {
+            match client.set_url(&u) {
+                Ok(c) => client = c,
+                Err(e) => {
+                    return Box::pin(async { Err(e) });
+                }
+            };
+        }
+        #[allow(unused_mut)]
+        let mut captcha;
+        match captval::Captcha::new(&self.token) {
+            Ok(c) => captcha = c,
+            Err(e) => {
+                return Box::pin(async { Err(e) });
+            }
+        };
+        let request;
+        match captval::Request::new(&secret, captcha) {
+            Ok(r) => request = r,
+            Err(e) => {
+                return Box::pin(async { Err(e) });
+            }
+        };
+        Box::pin(client.verify(request))
+    }
+}

--- a/crates/captval_derive/tests/expand/complete_struct.rs
+++ b/crates/captval_derive/tests/expand/complete_struct.rs
@@ -1,0 +1,13 @@
+use captval_derive::Captval;
+
+#[derive(Debug, Captval)]
+pub struct ContactForm {
+    name: String,
+    #[allow(dead_code)]
+    phone: String,
+    email: String,
+    #[allow(dead_code)]
+    message: String,
+    #[captcha]
+    token: String,
+}

--- a/crates/captval_derive/tests/expand/test.output.expanded.rs
+++ b/crates/captval_derive/tests/expand/test.output.expanded.rs
@@ -1,0 +1,67 @@
+use captval_derive::Captval;
+pub struct ContactForm {
+    name: String,
+    #[allow(dead_code)]
+    phone: String,
+    email: String,
+    #[allow(dead_code)]
+    message: String,
+    #[captcha]
+    token: String,
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for ContactForm {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::debug_struct_field5_finish(
+            f,
+            "ContactForm",
+            "name",
+            &self.name,
+            "phone",
+            &self.phone,
+            "email",
+            &self.email,
+            "message",
+            &self.message,
+            "token",
+            &&self.token,
+        )
+    }
+}
+impl Captval for ContactForm {
+    fn valid_response(
+        &self,
+        secret: &str,
+        uri: Option<String>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<captval::Response, captval::Error>>>,
+    > {
+        let mut client = captval::Client::new();
+        if let Some(u) = uri {
+            match client.set_url(&u) {
+                Ok(c) => client = c,
+                Err(e) => {
+                    return Box::pin(async { Err(e) });
+                }
+            };
+        }
+        -let mut captcha = String::new();
+        #[allow(unused_mut)]
+        let mut captcha;
+        match captval::Captcha::new(&self.token) {
+            Ok(c) => captcha = c,
+            Err(e) => {
+                return Box::pin(async { Err(e) });
+            }
+        };
+        let request;
+        match captval::Request::new(&secret, captcha) {
+            Ok(r) => request = r,
+            Err(e) => {
+                return Box::pin(async { Err(e) });
+            }
+        };
+        Box::pin(client.verify(request))
+    }
+}


### PR DESCRIPTION
- introduce a new test file for `ContactForm` struct with derived `Debug` and `Captval` implementations
- ensure proper handling and verification of captcha using `captval` library