### PR TITLE
✅ test(compile_fail): add tests for compile-time enum and struct validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✅ test(captval_derive)-add basic test cases for macro expansion(pr [#43])
 - ♻️ refactor(captval_derive)-remove unused variable(pr [#44])
 - ✅ test(expand)-add test for expanded contact form(pr [#45])
+- ✅ test(compile_fail)-add tests for compile-time enum and struct validation(pr [#46])
 
 ### Security
 
@@ -110,5 +111,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#43]: https://github.com/jerus-org/captval/pull/43
 [#44]: https://github.com/jerus-org/captval/pull/44
 [#45]: https://github.com/jerus-org/captval/pull/45
+[#46]: https://github.com/jerus-org/captval/pull/46
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/captval_derive/tests/compile_fail/complete_enum.rs
+++ b/crates/captval_derive/tests/compile_fail/complete_enum.rs
@@ -1,0 +1,12 @@
+use captval_derive::Captval;
+
+#[derive(Captval)]
+pub enum ContactEnum {
+    Name,
+    #[captcha]
+    Token,
+}
+
+fn main() {
+    println!("hello");
+}

--- a/crates/captval_derive/tests/compile_fail/complete_enum.stderr
+++ b/crates/captval_derive/tests/compile_fail/complete_enum.stderr
@@ -1,0 +1,14 @@
+error: Must derive on a struct
+
+         = help: This macro can only be implemented on a struct.
+
+               #[derive(Captval)]
+               struct MyStruct {
+                   #[captcha]
+                   captval: String,
+               }
+
+ --> tests/compile_fail/complete_enum.rs:4:10
+  |
+4 | pub enum ContactEnum {
+  |          ^^^^^^^^^^^

--- a/crates/captval_derive/tests/compile_fail/no_field_enum.rs
+++ b/crates/captval_derive/tests/compile_fail/no_field_enum.rs
@@ -1,0 +1,11 @@
+use captval_derive::Captval;
+
+#[derive(Captval)]
+pub enum ContactEnum {
+    Name,
+    Token,
+}
+
+fn main() {
+    println!("hello");
+}

--- a/crates/captval_derive/tests/compile_fail/no_field_enum.stderr
+++ b/crates/captval_derive/tests/compile_fail/no_field_enum.stderr
@@ -1,0 +1,14 @@
+error: Must derive on a struct
+
+         = help: This macro can only be implemented on a struct.
+
+               #[derive(Captval)]
+               struct MyStruct {
+                   #[captcha]
+                   captval: String,
+               }
+
+ --> tests/compile_fail/no_field_enum.rs:4:10
+  |
+4 | pub enum ContactEnum {
+  |          ^^^^^^^^^^^

--- a/crates/captval_derive/tests/compile_fail/no_field_struct.rs
+++ b/crates/captval_derive/tests/compile_fail/no_field_struct.rs
@@ -1,0 +1,16 @@
+use captval_derive::Captval;
+
+#[derive(Captval)]
+pub struct ContactForm {
+    name: String,
+    #[allow(dead_code)]
+    phone: String,
+    email: String,
+    #[allow(dead_code)]
+    message: String,
+    token: String,
+}
+
+fn main() {
+    println!("hello");
+}

--- a/crates/captval_derive/tests/compile_fail/no_field_struct.stderr
+++ b/crates/captval_derive/tests/compile_fail/no_field_struct.stderr
@@ -1,0 +1,14 @@
+error: Field containing captval not identified
+
+         = help: The field containing the captval response string must be identified with #[captcha]
+
+               #[derive(Captval)]
+               struct MyStruct {
+                   #[captcha]
+                   captval: String,
+               }
+
+ --> tests/compile_fail/no_field_struct.rs:4:12
+  |
+4 | pub struct ContactForm {
+  |            ^^^^^^^^^^^


### PR DESCRIPTION
- add compile-fail tests for enums using Captval derive to ensure correct usage
- verify structs require a field with #[captcha] for Captval derive to work properly