### PR TITLE
🔧 chore(cargo): update package metadata and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(client)-remove deprecated verify_client_response method(pr [#48])
 - 📝 docs(lib)-update code example annotations(pr [#49])
 - 👷 ci(circleci)-add test-features job to workflow(pr [#50])
+- 🔧 chore(cargo)-update package metadata and configuration(pr [#52])
 
 ### Security
 
@@ -122,5 +123,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#49]: https://github.com/jerus-org/captval/pull/49
 [#50]: https://github.com/jerus-org/captval/pull/50
 [#51]: https://github.com/jerus-org/captval/pull/51
+[#52]: https://github.com/jerus-org/captval/pull/52
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/captval/Cargo.toml
+++ b/crates/captval/Cargo.toml
@@ -2,9 +2,22 @@
 name = "captval"
 version = "0.1.0"
 description = "Captcha validators"
-license = "MIT"
 documentation = "https://docs.rs/captval"
 repository = "https://github.com/jerus-org/captval"
+authors = ["Jeremiah Russell <jrussell@jerus.ie>"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+categories = ["web-programming"]
+keywords = ["hcaptcha", "captcha", "security", "backend", "protection"]
+include = [
+    "**/*.rs",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "CHANGES.md",
+]
+
 edition.workspace = true
 rust-version.workspace = true
 publish = true

--- a/crates/captval_derive/Cargo.toml
+++ b/crates/captval_derive/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "captval_derive"
 version = "0.1.0"
-edition = "2021"
 description = """
 Derive macro for captval. Please use captval crate.
 """
@@ -20,6 +19,9 @@ include = [
     "LICENSE-MIT",
     "CHANGES.md",
 ]
+edition.workspace = true
+rust-version.workspace = true
+publish = true
 
 [lib]
 name = "captval_derive"


### PR DESCRIPTION
- add authors, readme, categories, and keywords to captval
- change license to "MIT OR Apache-2.0" for captval
- include additional files for captval
- set edition and rust-version to workspace for both packages
- allow publishing for both captval and captval_derive