### PR TITLE
♻️ refactor(test-wasm): rename struct field for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 📝 docs(lib)-update code example annotations(pr [#49])
 - 👷 ci(circleci)-add test-features job to workflow(pr [#50])
 - 🔧 chore(cargo)-update package metadata and configuration(pr [#52])
+- ♻️ refactor(test-wasm)-rename struct field for clarity(pr [#53])
 
 ### Security
 
@@ -124,5 +125,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#50]: https://github.com/jerus-org/captval/pull/50
 [#51]: https://github.com/jerus-org/captval/pull/51
 [#52]: https://github.com/jerus-org/captval/pull/52
+[#53]: https://github.com/jerus-org/captval/pull/53
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/test-wasm/src/lib.rs
+++ b/crates/test-wasm/src/lib.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 #[derive(Captval)]
 struct Test {
     #[captcha]
-    hcaptcha: String,
+    token: String,
 }
 
 #[wasm_bindgen]
@@ -14,7 +14,7 @@ pub async fn validate_standard() {
     let secret = "0x0000000000000000000000000000000000000000";
 
     let form = Test {
-        hcaptcha: response.to_string(),
+        token: response.to_string(),
     };
 
     let response = form.valid_response(secret, None).await;


### PR DESCRIPTION
- rename 'hcaptcha' field to 'token' for better clarity and understanding of its purpose