### PR TITLE
🔧 chore(release): update release configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 👷 ci(circleci)-add test-features job to workflow(pr [#50])
 - 🔧 chore(cargo)-update package metadata and configuration(pr [#52])
 - ♻️ refactor(test-wasm)-rename struct field for clarity(pr [#53])
+- 🔧 chore(release)-update release configuration(pr [#54])
 
 ### Security
 
@@ -126,5 +127,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#51]: https://github.com/jerus-org/captval/pull/51
 [#52]: https://github.com/jerus-org/captval/pull/52
 [#53]: https://github.com/jerus-org/captval/pull/53
+[#54]: https://github.com/jerus-org/captval/pull/54
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/captval/release.toml
+++ b/crates/captval/release.toml
@@ -1,7 +1,7 @@
-pre-release-commit-message = "chore: Release"
+pre-release-commit-message = "chore: Release {{crate_name}} {{version}}"
 tag-message = "{{tag_name}}"
 tag-name = "{{prefix}}v{{version}}"
-consolidate-commits = true
+consolidate-commits = false
 allow-branch = ["main"]
 sign-commit = true
 sign-tag = true

--- a/crates/captval_derive/release.toml
+++ b/crates/captval_derive/release.toml
@@ -1,5 +1,5 @@
-pre-release-commit-message = "chore: Release"
+pre-release-commit-message = "chore: Release {{crate_name}} {{version}}"
 tag-message = "{{tag_name}}"
 tag-name = "{{prefix}}v{{version}}"
-consolidate-commits = true
+consolidate-commits = false
 allow-branch = ["main"]

--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,7 @@
-pre-release-commit-message = "chore: Release"
-tag-message = "{{tag_name}}"
+pre-release-commit-message = "chore: Release {{crate_name}} {{version}}"
+tag-message = "chore: Release {{crate_name}} version {{tag_name}}"
 tag-name = "{{prefix}}v{{version}}"
-consolidate-commits = true
+consolidate-commits = false
 allow-branch = ["main"]
 sign-commit = true
 sign-tag = true
@@ -9,7 +9,7 @@ pre-release-replacements = [
     { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
     { file = "CHANGELOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
     { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
-    { file = "README.md", search = "hcaptcha = .*", replace = "{{crate_name}} = \"{{version}}\"" },
+    { file = "README.md", search = "captval = .*", replace = "{{crate_name}} = \"{{version}}\"" },
     { file = "src/lib.rs", search = "version = .+,", replace = "version = \"{{version}}\",", exactly = 1 },
     { file = "sonar-project.properties", search = "sonar.projectVersion=.+", replace = "sonar.projectVersion=\"{{version}}\",", exactly = 1 },
 ]


### PR DESCRIPTION
- customize pre-release commit message to include crate name and version
- prevent commit consolidation for detailed commit history
- enhance tag message format to specify crate and version
- correct README replacement pattern for crate name