### PR TITLE
👷 ci(circleci): remove redundant jobs from release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,20 +151,9 @@ workflows:
         - not: << pipeline.parameters.success-flag >>
         - not: << pipeline.parameters.validation-flag >>
     jobs:
-      - toolkit/save_next_version:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
-
       - toolkit/make_release:
           min_rust_version: << pipeline.parameters.min-rust-version >>
-          requires:
-            - toolkit/save_next_version
           context:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
-
-      - toolkit/no_release:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
-          requires:
-            - toolkit/save_next_version:
-                - failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(cargo)-update package metadata and configuration(pr [#52])
 - ♻️ refactor(test-wasm)-rename struct field for clarity(pr [#53])
 - 🔧 chore(release)-update release configuration(pr [#54])
+- 👷 ci(circleci)-remove redundant jobs from release workflow(pr [#55])
 
 ### Security
 
@@ -128,5 +129,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#52]: https://github.com/jerus-org/captval/pull/52
 [#53]: https://github.com/jerus-org/captval/pull/53
 [#54]: https://github.com/jerus-org/captval/pull/54
+[#55]: https://github.com/jerus-org/captval/pull/55
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0


### PR DESCRIPTION
- remove `toolkit/save_next_version` and `toolkit/no_release` jobs
- streamline release workflow by eliminating unnecessary dependencies