### PR TITLE
👷 ci(circleci): update toolkit orb and refine release jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - checkout
       - run: cargo +stable --version
       - run:
-          name: Running test with features `<<parameters.features>>`
+          name: Running test with features - \"<<parameters.features>>\"
           command: "cargo +stable test --no-default-features <<parameters.features>>"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     description: "If true, the release pipeline will be executed."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@2.10.10
+  toolkit: jerus-org/circleci-toolkit@2.11.0
   # sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
@@ -152,8 +152,23 @@ workflows:
         - not: << pipeline.parameters.validation-flag >>
     jobs:
       - toolkit/make_release:
-          min_rust_version: << pipeline.parameters.min-rust-version >>
+          name: cargo release
           context:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+          echo: true
+          when_github_release: false
+
+      - toolkit/make_release:
+          requires:
+            - cargo release
+          name: github release for hcaptcha
+          context:
+            - release
+            - bot-check
+          ssh_fingerprint: << pipeline.parameters.fingerprint >>
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+          when_cargo_release: false
+          package: captval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(release)-update release configuration(pr [#54])
 - 👷 ci(circleci)-remove redundant jobs from release workflow(pr [#55])
 - ♻️ refactor(release)-update release configuration for captval(pr [#56])
+- 👷 ci(circleci)-update toolkit orb and refine release jobs(pr [#57])
 
 ### Security
 
@@ -132,5 +133,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/jerus-org/captval/pull/54
 [#55]: https://github.com/jerus-org/captval/pull/55
 [#56]: https://github.com/jerus-org/captval/pull/56
+[#57]: https://github.com/jerus-org/captval/pull/57
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0


### PR DESCRIPTION
- update toolkit orb version to 2.11.0
- add cargo release job with specific configuration
- refine github release job requirements and parameters