### PR TITLE
📦 build(captval): bump version to 0.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - checkout
       - run: cargo +stable --version
       - run:
-          name: Running test with features-|<<parameters.features>>|
+          name: Running test with features-H<<parameters.features>>H
           command: "cargo +stable test --no-default-features <<parameters.features>>"
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(release)-update release configuration for captval(pr [#56])
 - 👷 ci(circleci)-update toolkit orb and refine release jobs(pr [#57])
 - 👷 ci(circleci)-fix test command syntax in config(pr [#58])
+- 📦 build(captval)-bump version to 0.1.1(pr [#59])
 
 ### Security
 
@@ -136,5 +137,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#56]: https://github.com/jerus-org/captval/pull/56
 [#57]: https://github.com/jerus-org/captval/pull/57
 [#58]: https://github.com/jerus-org/captval/pull/58
+[#59]: https://github.com/jerus-org/captval/pull/59
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "captval"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "captval_derive",
  "chrono",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "captval_derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "captval",
  "macrotest",

--- a/crates/captval/Cargo.toml
+++ b/crates/captval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "captval"
-version = "0.1.0"
+version = "0.1.1"
 description = "Captcha validators"
 documentation = "https://docs.rs/captval"
 repository = "https://github.com/jerus-org/captval"
@@ -23,7 +23,7 @@ rust-version.workspace = true
 publish = true
 
 [dependencies]
-captval_derive = { path = "../captval_derive" }
+captval_derive = { version = "0.1.1", path = "../captval_derive" }
 hex = { workspace = true, optional = true }
 reqwest.workspace = true
 serde.workspace = true

--- a/crates/captval_derive/Cargo.toml
+++ b/crates/captval_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "captval_derive"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Derive macro for captval. Please use captval crate.
 """


### PR DESCRIPTION
- update version in Cargo.toml and Cargo.lock for captval and captval_derive
- ensure dependencies reflect the new version for compatibility