### PR TITLE
👷 ci(circleci): remove github release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,6 @@ workflows:
         - not: << pipeline.parameters.validation-flag >>
     jobs:
       - toolkit/make_release:
-          name: cargo release
           context:
             - release
             - bot-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,16 +159,3 @@ workflows:
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
           echo: true
-          when_github_release: false
-
-      - toolkit/make_release:
-          requires:
-            - cargo release
-          name: github release for hcaptcha
-          context:
-            - release
-            - bot-check
-          ssh_fingerprint: << pipeline.parameters.fingerprint >>
-          min_rust_version: << pipeline.parameters.min-rust-version >>
-          when_cargo_release: false
-          package: captval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- 👷 ci(circleci)-remove github release job(pr [#60])
+
 ## [0.1.2] - 2025-05-15
 
 ### Added
@@ -138,5 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#57]: https://github.com/jerus-org/captval/pull/57
 [#58]: https://github.com/jerus-org/captval/pull/58
 [#59]: https://github.com/jerus-org/captval/pull/59
-[0.1.2]: https://github.com/jerus-org/captval/compare/v0.1.0...captval-v0.1.2
+[#60]: https://github.com/jerus-org/captval/pull/60
+[Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/jerus-org/captval/compare/v0.1.0...v0.1.2
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0


### PR DESCRIPTION
- delete unused github release job from CircleCI config for cleaner pipeline configuration
- ensure focus on essential CI tasks by removing redundant steps