### PR TITLE
💄 style(hcaptcha): simplify string formatting in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(config)-update renovate configuration for improved dependency management(pr [#61])
 - 🔧 chore(vscode)-add sonarlint connected mode configuration(pr [#62])
 - ♻️ refactor(tests)-update test directory naming for clarity(pr [#63])
+- 💄 style(hcaptcha)-simplify string formatting in tests(pr [#72])
 
 ### Fixed
 
@@ -170,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#69]: https://github.com/jerus-org/captval/pull/69
 [#70]: https://github.com/jerus-org/captval/pull/70
 [#71]: https://github.com/jerus-org/captval/pull/71
+[#72]: https://github.com/jerus-org/captval/pull/72
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.2...HEAD
 [0.1.2]: https://github.com/jerus-org/captval/compare/v0.1.0...v0.1.2
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/captval/src/hcaptcha/code.rs
+++ b/crates/captval/src/hcaptcha/code.rs
@@ -226,63 +226,63 @@ mod tests {
     #[test]
     fn test_fmt_missing_secret() {
         let code = Code::MissingSecret;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "Secret key is missing.");
     }
 
     #[test]
     fn test_fmt_invalid_secret() {
         let code = Code::InvalidSecret;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "Secret key is invalid or malformed.");
     }
 
     #[test]
     fn test_fmt_missing_user_ip() {
         let code = Code::MissingUserIp;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "User IP string is missing.");
     }
 
     #[test]
     fn test_fmt_invalid_user_ip() {
         let code = Code::InvalidUserIp;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "User IP string is invalid.");
     }
 
     #[test]
     fn test_fmt_missing_site_key() {
         let code = Code::MissingSiteKey;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "Site Key string is missing.");
     }
 
     #[test]
     fn test_fmt_invalid_site_key() {
         let code = Code::InvalidSiteKey;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "Site Key string is invalid.");
     }
 
     #[test]
     fn test_fmt_invlid_secret_ext_wrong_len() {
         let code = Code::InvalidSecretExtWrongLen;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "Secret key is not the correct length.");
     }
 
     #[test]
     fn test_fmt_invalid_secret_ext_no_hex() {
         let code = Code::InvalidSecretExtNotHex;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "Secret key is not a hex string.");
     }
 
     #[test]
     fn test_fmt_missing_response() {
         let code = Code::MissingResponse;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(
             formatted,
             "The response parameter (verification token) is missing."
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn test_fmt_invalid_response() {
         let code = Code::InvalidResponse;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(
             formatted,
             "The response parameter (verification token) is invalid or malformed."
@@ -302,14 +302,14 @@ mod tests {
     #[test]
     fn test_fmt_bad_request() {
         let code = Code::BadRequest;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "The request is invalid or malformed.");
     }
 
     #[test]
     fn test_fmt_invalid_already_seen() {
         let code = Code::InvalidAlreadySeen;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(
             formatted,
             "The response parameter has already been checked, or has another issue."
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn test_fmt_site_secret_mismatch() {
         let code = Code::SiteSecretMismatch;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(
             formatted,
             "The sitekey is not registered with the provided secret."
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn test_fmt_secret_version_unknown() {
         let code = Code::SecretVersionUnknown;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(
             formatted,
             "The version of the site secret is not recognise."
@@ -339,7 +339,7 @@ mod tests {
     #[test]
     fn test_fmt_invalid_secret_ext_not_hex() {
         let code = Code::InvalidSecretExtNotHex;
-        let formatted = format!("{}", code);
+        let formatted = format!("{code}");
         assert_eq!(formatted, "Secret key is not a hex string.");
     }
 
@@ -347,7 +347,7 @@ mod tests {
     fn test_fmt_unknown_error() {
         let error_message = "Some unknown error occurred.";
         let code = Code::Unknown(error_message.to_string());
-        let formatted = format!("{}", code);
-        assert_eq!(formatted, format!("Unkown error: {}", error_message));
+        let formatted = format!("{code}");
+        assert_eq!(formatted, format!("Unkown error: {error_message}"));
     }
 }

--- a/crates/captval/src/response.rs
+++ b/crates/captval/src/response.rs
@@ -162,11 +162,11 @@ impl fmt::Display for Response {
                 None => "".to_owned(),
             },
             match self.credit() {
-                Some(v) => format!("{}", v),
+                Some(v) => format!("{v}"),
                 None => "".to_owned(),
             },
             match self.error_codes() {
-                Some(v) => format!("{:?}", v),
+                Some(v) => format!("{v:?}"),
                 None => "".to_owned(),
             },
         )
@@ -675,8 +675,8 @@ mod tests {
                 score_reason: Some(reasons),
             };
 
-            let formatted = format!("{}", response);
-            println!("{}", formatted);
+            let formatted = format!("{response}");
+            println!("{formatted}");
             assert!(formatted.contains("Status:         true"));
             assert!(formatted.contains("Timestamp:      2023-01-01T00:00:00Z"));
             assert!(formatted.contains("Hostname:       test.com"));
@@ -725,7 +725,7 @@ mod tests {
             score_reason: None,
         };
 
-        let formatted = format!("{}", response);
+        let formatted = format!("{response}");
         assert!(formatted.contains("Status:         true"));
         assert!(formatted.contains("Timestamp:      "));
         assert!(formatted.contains("Hostname:       "));


### PR DESCRIPTION
- change format! macro usage to use named arguments for consistency and readability