### PR TITLE
♻️ refactor(captcha): rename ClientResponse to Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(tests)-update test directory naming for clarity(pr [#63])
 - 💄 style(hcaptcha)-simplify string formatting in tests(pr [#72])
 - ♻️ refactor(response)-streamline response formatting(pr [#73])
+- ♻️ refactor(captcha)-rename ClientResponse to Token(pr [#74])
 
 ### Fixed
 
@@ -174,6 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#71]: https://github.com/jerus-org/captval/pull/71
 [#72]: https://github.com/jerus-org/captval/pull/72
 [#73]: https://github.com/jerus-org/captval/pull/73
+[#74]: https://github.com/jerus-org/captval/pull/74
 [Unreleased]: https://github.com/jerus-org/captval/compare/v0.1.2...HEAD
 [0.1.2]: https://github.com/jerus-org/captval/compare/v0.1.0...v0.1.2
 [0.1.0]: https://github.com/jerus-org/captval/releases/tag/v0.1.0

--- a/crates/captval/src/captcha.rs
+++ b/crates/captval/src/captcha.rs
@@ -24,13 +24,13 @@
 //! # }
 //! ```
 
-use crate::{ClientResponse, Error, Remoteip, Sitekey};
+use crate::{Error, Remoteip, Sitekey, Token};
 
 /// Capture the Captcha data coming from the client.
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Captcha {
     /// The response string collected by client.
-    pub(crate) response: ClientResponse,
+    pub(crate) response: Token,
     /// The remoteip of the client.
     pub(crate) remoteip: Option<Remoteip>,
     /// The sitekey from the client.
@@ -94,7 +94,7 @@ impl Captcha {
     )]
     pub fn new(response: &str) -> Result<Self, Error> {
         Ok(Captcha {
-            response: ClientResponse::parse(response.to_owned())?,
+            response: Token::parse(response.to_owned())?,
             remoteip: None,
             sitekey: None,
         })
@@ -302,7 +302,7 @@ impl Captcha {
         feature = "trace",
         tracing::instrument(name = "Get response field.", level = "debug")
     )]
-    pub fn response(self) -> ClientResponse {
+    pub fn response(self) -> Token {
         self.response
     }
 

--- a/crates/captval/src/hcaptcha.rs
+++ b/crates/captval/src/hcaptcha.rs
@@ -13,7 +13,7 @@ mod sitekey;
 // pub(crate) use client_response::ClientResponse;
 pub use code::Code;
 
-pub use client_response::ClientResponse;
+pub use client_response::Token;
 #[cfg(not(feature = "ext"))]
 pub(crate) use secret::Secret;
 #[allow(unused_imports)]

--- a/crates/captval/src/hcaptcha/client_response.rs
+++ b/crates/captval/src/hcaptcha/client_response.rs
@@ -3,17 +3,17 @@ use std::collections::HashSet;
 use std::fmt;
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ClientResponse(String);
+pub struct Token(String);
 
-impl ClientResponse {
-    pub fn parse(s: String) -> Result<ClientResponse, Error> {
+impl Token {
+    pub fn parse(s: String) -> Result<Token, Error> {
         if s.trim().is_empty() {
             let mut codes = HashSet::new();
             codes.insert(Code::MissingResponse);
 
             Err(Error::Codes(codes))
         } else {
-            Ok(ClientResponse(s))
+            Ok(Token(s))
         }
     }
 
@@ -22,7 +22,7 @@ impl ClientResponse {
     }
 }
 
-impl fmt::Display for ClientResponse {
+impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -30,7 +30,7 @@ impl fmt::Display for ClientResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::ClientResponse;
+    use super::Token;
     use crate::Code;
     use crate::Error;
     use claims::assert_err;
@@ -38,27 +38,27 @@ mod tests {
     #[test]
     fn whitespace_only_names_are_rejected() {
         let response = " ".to_string();
-        assert_err!(ClientResponse::parse(response));
+        assert_err!(Token::parse(response));
     }
 
     #[test]
     fn empty_string_is_rejected() {
         let response = "".to_string();
-        assert_err!(ClientResponse::parse(response));
+        assert_err!(Token::parse(response));
     }
 
     #[test]
     fn error_set_contains_missing_response_error() {
         let response = "".to_string();
 
-        if let Err(Error::Codes(hs)) = ClientResponse::parse(response) {
+        if let Err(Error::Codes(hs)) = Token::parse(response) {
             assert!(hs.contains(&Code::MissingResponse));
         }
     }
 
     #[test]
     fn test_as_str() {
-        let response = ClientResponse("test_response".to_string());
+        let response = Token("test_response".to_string());
         assert_eq!(response.as_str(), "test_response");
     }
 }


### PR DESCRIPTION
- change all occurrences of ClientResponse to Token for clarity
- update related imports and function implementations to use Token